### PR TITLE
Refactor ListenBrainzPlugin to improve track identifier handling

### DIFF
--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -97,10 +97,13 @@ class ListenBrainzPlugin(BeetsPlugin):
         tracks = []
         for track in playlist.get("playlist").get("track"):
             self._log.debug(f"Track: {track}")
+            identifier = track.get("identifier")
+            if isinstance(identifier, list):
+                identifier = identifier[0]
             tracks.append(
                 {
                     "artist": track.get("creator"),
-                    "identifier": track.get("identifier").split("/")[-1],
+                    "identifier": identifier.split("/")[-1],
                     "title": track.get("title"),
                 }
             )

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -99,13 +99,13 @@ class ListenBrainzPlugin(BeetsPlugin):
             identifier = track.get("identifier")
             if isinstance(identifier, list):
                 identifier = identifier[0]
-            tracks.append(
-                {
-                    "artist": track.get("creator"),
-                    "identifier": identifier.split("/")[-1],
-                    "title": track.get("title"),
-                }
-            )
+            track_dict = {
+                "artist": track.get("creator"),
+                "identifier": identifier.split("/")[-1],
+                "title": track.get("title"),
+            }
+            self._log.debug(f"Track: {track_dict}")
+            tracks.append(track_dict)
         return self.get_track_info(tracks)
 
     def get_track_info(self, tracks):
@@ -144,7 +144,6 @@ class ListenBrainzPlugin(BeetsPlugin):
     def get_weekly_playlist(self, index):
         """Returns a list of weekly playlists based on the index."""
         playlists = self.get_listenbrainz_playlists()
-        self._log.debug(f"Found Playlists: {playlists}")
         playlist = self.get_playlist(playlists[index].get("identifier"))
         return self.get_tracks_from_playlist(playlist)
 
@@ -154,11 +153,11 @@ class ListenBrainzPlugin(BeetsPlugin):
 
     def get_weekly_jams(self):
         """Returns a list of weekly jams."""
-        return self.get_weekly_playlist(2)
+        return self.get_weekly_playlist(1)
 
     def get_last_weekly_exploration(self):
         """Returns a list of weekly exploration."""
-        return self.get_weekly_playlist(1)
+        return self.get_weekly_playlist(2)
 
     def get_last_weekly_jams(self):
         """Returns a list of weekly jams."""

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -144,7 +144,8 @@ class ListenBrainzPlugin(BeetsPlugin):
     def get_weekly_playlist(self, index):
         """Returns a list of weekly playlists based on the index."""
         playlists = self.get_listenbrainz_playlists()
-        self._log.debug("Playlists: %s", playlists)
+        formatted_message = "Playlists: {}".format(playlists)
+        self._log.debug(formatted_message)
         playlist = self.get_playlist(playlists[index].get("identifier"))
         return self.get_tracks_from_playlist(playlist)
 

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -99,8 +99,9 @@ class ListenBrainzPlugin(BeetsPlugin):
             identifier = track.get("identifier")
             if isinstance(identifier, list):
                 identifier = identifier[0]
+            artist = track.get("creator", "Unknown artist")  # Set a default value if 'creator' key is not present
             track_dict = {
-                "artist": track.get("creator"),
+                "artist": artist,
                 "identifier": identifier.split("/")[-1],
                 "title": track.get("title"),
             }

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -96,6 +96,7 @@ class ListenBrainzPlugin(BeetsPlugin):
         """This function returns a list of tracks in the playlist."""
         tracks = []
         for track in playlist.get("playlist").get("track"):
+            self._log.debug(f"Track: {str(track)}")  # Convert dictionary to string before logging
             identifier = track.get("identifier")
             if isinstance(identifier, list):
                 identifier = identifier[0]

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -141,26 +141,27 @@ class ListenBrainzPlugin(BeetsPlugin):
             )
         return track_info
 
-    def get_weekly_playlist(self, index):
-        """Returns a list of weekly playlists based on the index."""
+    def get_weekly_playlist(self, playlist_type, most_recent=True):
+        # Fetch all playlists
         playlists = self.get_listenbrainz_playlists()
-        for playlist in playlists:
-            self._log.debug(playlist["type"] + " - " + str(playlist["date"]))
-        playlist = self.get_playlist(playlists[index].get("identifier"))
+        # Filter playlists by type
+        filtered_playlists = [p for p in playlists if p["type"] == playlist_type]
+        # Sort playlists by date in descending order
+        sorted_playlists = sorted(filtered_playlists, key=lambda x: x["date"], reverse=True)
+        # Select the most recent or older playlist based on the most_recent flag
+        selected_playlist = sorted_playlists[0] if most_recent else sorted_playlists[1]
+        # Fetch and return tracks from the selected playlist
+        playlist = self.get_playlist(selected_playlist.get("identifier"))
         return self.get_tracks_from_playlist(playlist)
 
     def get_weekly_exploration(self):
-        """Returns a list of weekly exploration."""
-        return self.get_weekly_playlist(0)
+        return self.get_weekly_playlist("Exploration", most_recent=True)
 
     def get_weekly_jams(self):
-        """Returns a list of weekly jams."""
-        return self.get_weekly_playlist(1)
+        return self.get_weekly_playlist("Jams", most_recent=True)
 
     def get_last_weekly_exploration(self):
-        """Returns a list of weekly exploration."""
-        return self.get_weekly_playlist(2)
+        return self.get_weekly_playlist("Exploration", most_recent=False)
 
     def get_last_weekly_jams(self):
-        """Returns a list of weekly jams."""
-        return self.get_weekly_playlist(3)
+        return self.get_weekly_playlist("Jams", most_recent=False)

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -144,7 +144,7 @@ class ListenBrainzPlugin(BeetsPlugin):
     def get_weekly_playlist(self, index):
         """Returns a list of weekly playlists based on the index."""
         playlists = self.get_listenbrainz_playlists()
-        self._log.debug(f"Playlists: {playlists}")
+        self._log.debug("Playlists: %s", playlists)
         playlist = self.get_playlist(playlists[index].get("identifier"))
         return self.get_tracks_from_playlist(playlist)
 

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -144,6 +144,7 @@ class ListenBrainzPlugin(BeetsPlugin):
     def get_weekly_playlist(self, index):
         """Returns a list of weekly playlists based on the index."""
         playlists = self.get_listenbrainz_playlists()
+        self._log.debug(f"Playlists: {playlists}")
         playlist = self.get_playlist(playlists[index].get("identifier"))
         return self.get_tracks_from_playlist(playlist)
 

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -96,7 +96,6 @@ class ListenBrainzPlugin(BeetsPlugin):
         """This function returns a list of tracks in the playlist."""
         tracks = []
         for track in playlist.get("playlist").get("track"):
-            self._log.debug(f"Track: {track}")
             identifier = track.get("identifier")
             if isinstance(identifier, list):
                 identifier = identifier[0]
@@ -145,6 +144,7 @@ class ListenBrainzPlugin(BeetsPlugin):
     def get_weekly_playlist(self, index):
         """Returns a list of weekly playlists based on the index."""
         playlists = self.get_listenbrainz_playlists()
+        self._log.debug(f"Found Playlists: {playlists}")
         playlist = self.get_playlist(playlists[index].get("identifier"))
         return self.get_tracks_from_playlist(playlist)
 

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -105,7 +105,7 @@ class ListenBrainzPlugin(BeetsPlugin):
                 "identifier": identifier.split("/")[-1],
                 "title": track.get("title"),
             }
-            self._log.debug(f"Track: {track_dict}")
+            self._log.debug(f"Track: {str(track_dict)}")  # Convert dictionary to string before logging
             tracks.append(track_dict)
         return self.get_track_info(tracks)
 

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -144,8 +144,9 @@ class ListenBrainzPlugin(BeetsPlugin):
     def get_weekly_playlist(self, index):
         """Returns a list of weekly playlists based on the index."""
         playlists = self.get_listenbrainz_playlists()
-        formatted_message = "Playlists: {}".format(playlists)
-        self._log.debug(formatted_message)
+        for playlist in playlists:
+            self._log.debug(playlists["type"])
+
         playlist = self.get_playlist(playlists[index].get("identifier"))
         return self.get_tracks_from_playlist(playlist)
 

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -145,8 +145,7 @@ class ListenBrainzPlugin(BeetsPlugin):
         """Returns a list of weekly playlists based on the index."""
         playlists = self.get_listenbrainz_playlists()
         for playlist in playlists:
-            self._log.debug(playlist["type"])
-
+            self._log.debug(playlist["type"] + " - " + str(playlist["date"]))
         playlist = self.get_playlist(playlists[index].get("identifier"))
         return self.get_tracks_from_playlist(playlist)
 

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -96,7 +96,6 @@ class ListenBrainzPlugin(BeetsPlugin):
         """This function returns a list of tracks in the playlist."""
         tracks = []
         for track in playlist.get("playlist").get("track"):
-            self._log.debug(f"Track: {str(track)}")  # Convert dictionary to string before logging
             identifier = track.get("identifier")
             if isinstance(identifier, list):
                 identifier = identifier[0]
@@ -106,7 +105,6 @@ class ListenBrainzPlugin(BeetsPlugin):
                 "identifier": identifier.split("/")[-1],
                 "title": track.get("title"),
             }
-            self._log.debug(f"Track: {str(track_dict)}")  # Convert dictionary to string before logging
             tracks.append(track_dict)
         return self.get_track_info(tracks)
 

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -145,7 +145,7 @@ class ListenBrainzPlugin(BeetsPlugin):
         """Returns a list of weekly playlists based on the index."""
         playlists = self.get_listenbrainz_playlists()
         for playlist in playlists:
-            self._log.debug(playlists["type"])
+            self._log.debug(playlist["type"])
 
         playlist = self.get_playlist(playlists[index].get("identifier"))
         return self.get_tracks_from_playlist(playlist)

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -96,6 +96,7 @@ class ListenBrainzPlugin(BeetsPlugin):
         """This function returns a list of tracks in the playlist."""
         tracks = []
         for track in playlist.get("playlist").get("track"):
+            self._log.debug(f"Track: {track}")
             tracks.append(
                 {
                     "artist": track.get("creator"),


### PR DESCRIPTION
This pull request refactors the ListenBrainzPlugin to improve the handling of track identifiers. It fixes an issue where the track identifier was not correctly extracted from the identifier field. Additionally, it sets a default value for the artist if the 'creator' key is not present. These changes improve the reliability and accuracy of the plugin.